### PR TITLE
reorganize imports

### DIFF
--- a/src/actinia_satellite_plugin/aws_sentinel2a_query.py
+++ b/src/actinia_satellite_plugin/aws_sentinel2a_query.py
@@ -5,7 +5,7 @@
 from actinia_core.resources.common.config import global_config
 from flask import jsonify, make_response
 from actinia_core.resources.common.app import auth
-from actinia_core.resources.common.logging_interface import log_api_call
+from actinia_core.resources.common.api_logger import log_api_call
 from actinia_core.resources.common.response_models import SimpleResponseModel
 from actinia_core.resources.common.aws_sentinel_interface import AWSSentinel2AInterface
 from actinia_core.resources.resource_base import ResourceBase

--- a/src/actinia_satellite_plugin/ephemeral_landsat_ndvi_processor.py
+++ b/src/actinia_satellite_plugin/ephemeral_landsat_ndvi_processor.py
@@ -6,7 +6,7 @@ from copy import deepcopy
 from flask import jsonify, make_response
 from actinia_core.resources.common.process_object import Process
 from actinia_core.resources.common.app import auth
-from actinia_core.resources.common.logging_interface import log_api_call
+from actinia_core.resources.common.api_logger import log_api_call
 from flask_restful_swagger_2 import swagger
 from actinia_core.resources.resource_base import ResourceBase
 from actinia_core.resources.ephemeral_processing_with_export import EphemeralProcessingWithExport

--- a/src/actinia_satellite_plugin/ephemeral_sentinel2_ndvi_processor.py
+++ b/src/actinia_satellite_plugin/ephemeral_sentinel2_ndvi_processor.py
@@ -14,7 +14,7 @@ from actinia_core.resources.common.process_object import Process
 from actinia_core.resources.common.exceptions import AsyncProcessError
 from actinia_core.resources.common.response_models import UnivarResultModel, ProcessingResponseModel
 from actinia_core.resources.common.app import auth
-from actinia_core.resources.common.logging_interface import log_api_call
+from actinia_core.resources.common.api_logger import log_api_call
 from actinia_core.resources.common.response_models import ProcessingErrorResponseModel
 
 __license__ = "GPLv3"

--- a/src/actinia_satellite_plugin/satellite_query.py
+++ b/src/actinia_satellite_plugin/satellite_query.py
@@ -11,7 +11,7 @@ from flask_restful import reqparse
 from actinia_core.resources.common.config import global_config
 from actinia_core.resources.common.google_satellite_bigquery_interface import GoogleSatelliteBigQueryInterface
 from actinia_core.resources.common.app import auth
-from actinia_core.resources.common.logging_interface import log_api_call
+from actinia_core.resources.common.api_logger import log_api_call
 from actinia_core.resources.common.response_models import SimpleResponseModel
 
 __license__ = "GPLv3"
@@ -345,4 +345,3 @@ class Sentinel2Query(SatelliteQuery):
     def get(self):
         """Query the Google Sentinel2 archives using time interval, lat/lon coordinates, scene id and cloud cover."""
         return self._get("sentinel2")
-


### PR DESCRIPTION
This PR changes the source of 4 import statements from `logging_interface` to `api_logger`. As `logging_interface` did import itself from `api_logger`, this won't change functional code but will be needed for https://github.com/mundialis/actinia_core/pull/47.

Also related to https://github.com/mundialis/actinia_statistic_plugin/pull/4