### PR TITLE
Move actinia_core imports

### DIFF
--- a/scripts/main.py
+++ b/scripts/main.py
@@ -8,10 +8,10 @@ import os
 from src.actinia_satellite_plugin.endpoints import create_endpoints
 from actinia_core.health_check import health_check
 from actinia_core.version import version
-from actinia_core.resources.common.app import flask_app
-from actinia_core.resources.common.config import global_config, DEFAULT_CONFIG_PATH
-from actinia_core.resources.common.redis_interface import connect, create_job_queues
-from actinia_core.resources.common.process_queue import create_process_queue
+from actinia_core.core.common.app import flask_app
+from actinia_core.core.common.config import global_config, DEFAULT_CONFIG_PATH
+from actinia_core.core.common.redis_interface import connect, create_job_queues
+from actinia_core.core.common.process_queue import create_process_queue
 
 __license__ = "GPLv3"
 __author__     = "Sören Gebbert"

--- a/src/actinia_satellite_plugin/aws_sentinel2a_query.py
+++ b/src/actinia_satellite_plugin/aws_sentinel2a_query.py
@@ -2,13 +2,13 @@
 """
 """
 
-from actinia_core.resources.common.config import global_config
+from actinia_core.core.common.config import global_config
 from flask import jsonify, make_response
-from actinia_core.resources.common.app import auth
-from actinia_core.resources.common.api_logger import log_api_call
-from actinia_core.resources.common.response_models import SimpleResponseModel
-from actinia_core.resources.common.aws_sentinel_interface import AWSSentinel2AInterface
-from actinia_core.resources.resource_base import ResourceBase
+from actinia_core.core.common.app import auth
+from actinia_core.core.common.api_logger import log_api_call
+from actinia_core.models.response_models import SimpleResponseModel
+from actinia_core.core.common.aws_sentinel_interface import AWSSentinel2AInterface
+from actinia_core.rest.resource_base import ResourceBase
 from flask_restful_swagger_2 import swagger, Schema
 from copy import deepcopy
 

--- a/src/actinia_satellite_plugin/ephemeral_landsat_ndvi_processor.py
+++ b/src/actinia_satellite_plugin/ephemeral_landsat_ndvi_processor.py
@@ -12,9 +12,9 @@ from actinia_core.rest.resource_base import ResourceBase
 from actinia_core.rest.ephemeral_processing_with_export import EphemeralProcessingWithExport
 from actinia_core.core.common.redis_interface import enqueue_job
 from actinia_core.core.common.exceptions import AsyncProcessError
-from actinia_core.core.common.response_models import UnivarResultModel, ProcessingResponseModel
+from actinia_core.models.response_models import UnivarResultModel, ProcessingResponseModel
 from actinia_core.core.common.landsat_processing_library import LandsatProcessing
-from actinia_core.core.common.response_models import ProcessingErrorResponseModel
+from actinia_core.models.response_models import ProcessingErrorResponseModel
 
 __license__ = "GPLv3"
 __author__ = "Sören Gebbert"

--- a/src/actinia_satellite_plugin/ephemeral_landsat_ndvi_processor.py
+++ b/src/actinia_satellite_plugin/ephemeral_landsat_ndvi_processor.py
@@ -4,17 +4,17 @@ import os
 import tempfile
 from copy import deepcopy
 from flask import jsonify, make_response
-from actinia_core.resources.common.process_object import Process
-from actinia_core.resources.common.app import auth
-from actinia_core.resources.common.api_logger import log_api_call
+from actinia_core.core.common.process_object import Process
+from actinia_core.core.common.app import auth
+from actinia_core.core.common.api_logger import log_api_call
 from flask_restful_swagger_2 import swagger
-from actinia_core.resources.resource_base import ResourceBase
-from actinia_core.resources.ephemeral_processing_with_export import EphemeralProcessingWithExport
-from actinia_core.resources.common.redis_interface import enqueue_job
-from actinia_core.resources.common.exceptions import AsyncProcessError
-from actinia_core.resources.common.response_models import UnivarResultModel, ProcessingResponseModel
-from actinia_core.resources.common.landsat_processing_library import LandsatProcessing
-from actinia_core.resources.common.response_models import ProcessingErrorResponseModel
+from actinia_core.rest.resource_base import ResourceBase
+from actinia_core.rest.ephemeral_processing_with_export import EphemeralProcessingWithExport
+from actinia_core.core.common.redis_interface import enqueue_job
+from actinia_core.core.common.exceptions import AsyncProcessError
+from actinia_core.core.common.response_models import UnivarResultModel, ProcessingResponseModel
+from actinia_core.core.common.landsat_processing_library import LandsatProcessing
+from actinia_core.core.common.response_models import ProcessingErrorResponseModel
 
 __license__ = "GPLv3"
 __author__ = "Sören Gebbert"

--- a/src/actinia_satellite_plugin/ephemeral_sentinel2_ndvi_processor.py
+++ b/src/actinia_satellite_plugin/ephemeral_sentinel2_ndvi_processor.py
@@ -12,7 +12,7 @@ from actinia_core.core.common.redis_interface import enqueue_job
 from actinia_core.core.common.sentinel_processing_library import Sentinel2Processing
 from actinia_core.core.common.process_object import Process
 from actinia_core.core.common.exceptions import AsyncProcessError
-from actinia_core.core.common.response_models import UnivarResultModel, ProcessingResponseModel
+from actinia_core.models.response_models import UnivarResultModel, ProcessingResponseModel
 from actinia_core.core.common.app import auth
 from actinia_core.core.common.api_logger import log_api_call
 from actinia_core.models.response_models import ProcessingErrorResponseModel

--- a/src/actinia_satellite_plugin/ephemeral_sentinel2_ndvi_processor.py
+++ b/src/actinia_satellite_plugin/ephemeral_sentinel2_ndvi_processor.py
@@ -5,17 +5,17 @@ import tempfile
 from copy import deepcopy
 from flask import jsonify, make_response
 from flask_restful_swagger_2 import swagger
-from actinia_core.resources.ephemeral_processing_with_export import EphemeralProcessingWithExport
-from actinia_core.resources.resource_base import ResourceBase
-from actinia_core.resources.common.google_satellite_bigquery_interface import GoogleSatelliteBigQueryInterface
-from actinia_core.resources.common.redis_interface import enqueue_job
-from actinia_core.resources.common.sentinel_processing_library import Sentinel2Processing
-from actinia_core.resources.common.process_object import Process
-from actinia_core.resources.common.exceptions import AsyncProcessError
-from actinia_core.resources.common.response_models import UnivarResultModel, ProcessingResponseModel
-from actinia_core.resources.common.app import auth
-from actinia_core.resources.common.api_logger import log_api_call
-from actinia_core.resources.common.response_models import ProcessingErrorResponseModel
+from actinia_core.rest.ephemeral_processing_with_export import EphemeralProcessingWithExport
+from actinia_core.rest.resource_base import ResourceBase
+from actinia_core.core.common.google_satellite_bigquery_interface import GoogleSatelliteBigQueryInterface
+from actinia_core.core.common.redis_interface import enqueue_job
+from actinia_core.core.common.sentinel_processing_library import Sentinel2Processing
+from actinia_core.core.common.process_object import Process
+from actinia_core.core.common.exceptions import AsyncProcessError
+from actinia_core.core.common.response_models import UnivarResultModel, ProcessingResponseModel
+from actinia_core.core.common.app import auth
+from actinia_core.core.common.api_logger import log_api_call
+from actinia_core.models.response_models import ProcessingErrorResponseModel
 
 __license__ = "GPLv3"
 __author__     = "Sören Gebbert"

--- a/src/actinia_satellite_plugin/persistent_landsat_timeseries_creator.py
+++ b/src/actinia_satellite_plugin/persistent_landsat_timeseries_creator.py
@@ -9,13 +9,13 @@ import dateutil.parser as dtparser
 from datetime import timedelta
 from copy import deepcopy
 from flask_restful_swagger_2 import swagger, Schema
-from actinia_core.resources.common.response_models import  ProcessingResponseModel, ProcessingErrorResponseModel
-from actinia_core.resources.persistent_processing import PersistentProcessing
-from actinia_core.resources.resource_base import ResourceBase
-from actinia_core.resources.common.redis_interface import enqueue_job
-from actinia_core.resources.common.google_satellite_bigquery_interface import GoogleSatelliteBigQueryInterface
-from actinia_core.resources.common.landsat_processing_library import LandsatProcessing, SCENE_BANDS, extract_sensor_id_from_scene_id, RASTER_SUFFIXES
-from actinia_core.resources.common.exceptions import AsyncProcessError
+from actinia_core.models.response_models import  ProcessingResponseModel, ProcessingErrorResponseModel
+from actinia_core.rest.persistent_processing import PersistentProcessing
+from actinia_core.rest.resource_base import ResourceBase
+from actinia_core.core.common.redis_interface import enqueue_job
+from actinia_core.core.common.google_satellite_bigquery_interface import GoogleSatelliteBigQueryInterface
+from actinia_core.core.common.landsat_processing_library import LandsatProcessing, SCENE_BANDS, extract_sensor_id_from_scene_id, RASTER_SUFFIXES
+from actinia_core.core.common.exceptions import AsyncProcessError
 
 __license__ = "GPLv3"
 __author__     = "Sören Gebbert"

--- a/src/actinia_satellite_plugin/persistent_sentinel2_timeseries_creator.py
+++ b/src/actinia_satellite_plugin/persistent_sentinel2_timeseries_creator.py
@@ -8,13 +8,13 @@ import dateutil.parser as dtparser
 from datetime import timedelta
 from copy import deepcopy
 from flask_restful_swagger_2 import swagger, Schema
-from actinia_core.resources.common.response_models import  ProcessingResponseModel, ProcessingErrorResponseModel
-from actinia_core.resources.persistent_processing import PersistentProcessing
-from actinia_core.resources.resource_base import ResourceBase
-from actinia_core.resources.common.redis_interface import enqueue_job
-from actinia_core.resources.common.google_satellite_bigquery_interface import GoogleSatelliteBigQueryInterface
-from actinia_core.resources.common.sentinel_processing_library import Sentinel2Processing
-from actinia_core.resources.common.exceptions import AsyncProcessError
+from actinia_core.models.response_models import  ProcessingResponseModel, ProcessingErrorResponseModel
+from actinia_core.rest.persistent_processing import PersistentProcessing
+from actinia_core.rest.resource_base import ResourceBase
+from actinia_core.core.common.redis_interface import enqueue_job
+from actinia_core.core.common.google_satellite_bigquery_interface import GoogleSatelliteBigQueryInterface
+from actinia_core.core.common.sentinel_processing_library import Sentinel2Processing
+from actinia_core.core.common.exceptions import AsyncProcessError
 
 __license__ = "GPLv3"
 __author__     = "Sören Gebbert"

--- a/src/actinia_satellite_plugin/satellite_query.py
+++ b/src/actinia_satellite_plugin/satellite_query.py
@@ -8,11 +8,11 @@ from flask_restful import Resource
 from flask_restful_swagger_2 import swagger, Schema
 from copy import deepcopy
 from flask_restful import reqparse
-from actinia_core.resources.common.config import global_config
-from actinia_core.resources.common.google_satellite_bigquery_interface import GoogleSatelliteBigQueryInterface
-from actinia_core.resources.common.app import auth
-from actinia_core.resources.common.api_logger import log_api_call
-from actinia_core.resources.common.response_models import SimpleResponseModel
+from actinia_core.core.common.config import global_config
+from actinia_core.core.common.google_satellite_bigquery_interface import GoogleSatelliteBigQueryInterface
+from actinia_core.core.common.app import auth
+from actinia_core.core.common.api_logger import log_api_call
+from actinia_core.models.response_models import SimpleResponseModel
 
 __license__ = "GPLv3"
 __author__     = "Sören Gebbert"

--- a/tests/test_resource_base.py
+++ b/tests/test_resource_base.py
@@ -5,8 +5,8 @@ import signal
 import time
 from flask_restful import Api
 from actinia_core.testsuite import ActiniaTestCaseBase, URL_PREFIX
-from actinia_core.resources.common.config import global_config
-from actinia_core.resources.common.app import flask_app, flask_api
+from actinia_core.core.common.config import global_config
+from actinia_core.core.common.app import flask_app, flask_api
 from actinia_satellite_plugin.endpoints import create_endpoints
 from actinia_core.endpoints import create_endpoints as create_actinia_endpoints
 


### PR DESCRIPTION
As the modules follow a new folder structure in actinia_core, the imports needed to be adjusted.
See mundialis/actinia_core#221 and https://github.com/mundialis/actinia-module-plugin/pull/8
